### PR TITLE
fix production deployment with precompiled assets

### DIFF
--- a/lib/formtastic-epiceditor.rb
+++ b/lib/formtastic-epiceditor.rb
@@ -6,5 +6,9 @@ module FormtasticEpiceditor
   class Engine < ::Rails::Engine
     require "formtastic"
     require "formtastic-epiceditor/inputs/epic_editor_input.rb"
+
+    initializer "formtastic-epiceditor.assets.precompile" do |app|
+      app.config.assets.precompile += %w(epiceditor/themes/**/*)
+    end
   end
 end

--- a/lib/formtastic-epiceditor/inputs/epic_editor_input.rb
+++ b/lib/formtastic-epiceditor/inputs/epic_editor_input.rb
@@ -17,6 +17,13 @@ class EpicEditorInput < Formtastic::Inputs::TextInput
   end
 
   private
+
+  def assets_base_path
+    example_path = '/themes/base/epiceditor.css'
+    precompiled_example_path = ActionController::Base.helpers.asset_path('epiceditor' + example_path)
+    File.dirname(precompiled_example_path).gsub(File.dirname(example_path), '')
+  end
+
   def buildInitScript(id)
     randNum = rand(1..100000)
     return """
@@ -26,7 +33,7 @@ class EpicEditorInput < Formtastic::Inputs::TextInput
         opts = {
           container: '#{id}-epiceditor',
           clientSideStorage: false,
-          basePath: '#{ActionController::Base.helpers.asset_path('epiceditor')}',
+          basePath: '#{assets_base_path}',
           theme: {
             base:'/themes/base/epiceditor.css',
             preview:'/themes/preview/preview-dark.css',

--- a/lib/formtastic-epiceditor/version.rb
+++ b/lib/formtastic-epiceditor/version.rb
@@ -1,3 +1,3 @@
 module FormtasticEpiceditor
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
rendering a formtastic form view with the epiceditor input in a production rails app gave me the following error: `...ActionView::Template::Error (epiceditor isn't precompiled):...`.

to fix this i changed the following:
- precompile all assets below the /theme directory (because these assets are lazy-loaded via javascript)
- build the complete asset paths on the server-side using the precompiled assets
